### PR TITLE
Add main property to metadata

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,10 @@
     "initials"
   ],
   "license": "MIT",
+  "main": [
+    "./avatar.js",
+    "./md5.js"
+  ],
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
Added `main` property to metadata so tools that use the `main` property (like https://github.com/ck86/main-bower-files#usage-with-gulp) work correctly.